### PR TITLE
Remove postgres, implement Pizza Tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,3 @@ documentation/site/
 
 # MinIO Data
 minio/data
-
-# Database Related
-databases/postgres/data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ ENV PYTHONPATH=/app \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
-    postgresql \
-    postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Poetry

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ With the docker containers running and the worker running in either a container 
 1. Add `data/data_test.tsv`
 1. TSV should be ETL-ed
 1. TSV moves to the `archive_dir` bucket
-1. Data inserted into Postgres
 
 ### File glob pattern matching
 For `handled_file_glob` pattern matching, the matchers should be provided as `_test.tsv|_updated.csv|.mp3` (no spaces).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Faust Worker Example
+# Cast-Iron Worker Example
 
 ## Getting Started
 
-The Faust Worker example leverages several Python libraries to accomplish the ETL process.
+The Cast-Iron Worker example leverages several Python libraries to accomplish the ETL process.
 * [Faust](https://faust.readthedocs.io/en/latest/index.html)
 * [Kafka](https://github.com/dpkp/kafka-python)
 * [Minio](https://docs.min.io/docs/python-client-api-reference.html)
@@ -28,7 +28,7 @@ $ poetry install
 ## Start the Worker
 
 1. Add `127.0.0.1 kafka` entry to your /etc/hosts file
-1. Start the Faust ETL worker
+1. Start the Cast-Iron ETL worker
     * Locally
     ```
     $ poetry shell

--- a/etl/__main__.py
+++ b/etl/__main__.py
@@ -3,7 +3,7 @@ from typing import AsyncIterable, Dict, List
 
 from etl.config import settings
 from etl.event_processor import GeneralEventProcessor, EtlConfigEventProcessor
-from etl.messaging.kafka import KafkaMessageProducer
+from etl.messaging.kafka_producer import KafkaMessageProducer
 from etl.object_store.minio import MinioObjectStore
 from etl.tasking.faust import FaustTaskSink, FaustAppConfig
 

--- a/etl/config.py
+++ b/etl/config.py
@@ -23,7 +23,6 @@ class Settings(BaseSettings):
     kafka_topic_castiron_etl_config = 'castiron_etl_config'
     kafka_topic_castiron_etl_source_file = 'castiron_etl_source_file'
 
-    kafka_store_topic: str = 'postgres'
     kafka_pizza_tracker_topic: str = 'pizza-tracker'
 
     minio_etl_bucket: str = 'etl'
@@ -34,6 +33,8 @@ class Settings(BaseSettings):
 
     minio_notification_arn_etl_config: str = 'arn:minio:sqs::config:kafka'
     minio_notification_arn_etl_source_file: str = 'arn:minio:sqs::source:kafka'
+
+    log_level: str = 'debug'
 
 
 settings = Settings()

--- a/etl/event_processor.py
+++ b/etl/event_processor.py
@@ -188,6 +188,8 @@ class GeneralEventProcessor:
                             if processor.python.supports_pizza_tracker:
                                 LOGGER.debug('processor supports pizza tracker, starting tracker process now')
                                 pizza_tracker.process()
+                            else:
+                                LOGGER.warning(f'processor {config_object_id} does not support pizza tracker')
 
                             run_process.join()
                             success = True

--- a/etl/messaging/kafka_producer.py
+++ b/etl/messaging/kafka_producer.py
@@ -1,5 +1,6 @@
 """Contains implementation of MessageProducer backend using Kafka"""
 from json import dumps
+from typing import Any
 
 from kafka import KafkaProducer
 
@@ -11,11 +12,14 @@ class KafkaMessageProducer(MessageProducer):
     """Implementation of MessageProducer backend using Kafka"""
 
     def __init__(self):
-        self._producer = KafkaProducer(bootstrap_servers=[settings.kafka_broker],
-                                       value_serializer=lambda x: dumps(x).encode('utf-8'))
+        self._producer = KafkaProducer(bootstrap_servers=[settings.kafka_broker])
+
+    def _publish(self, data: Any):
+        self._producer.send(settings.kafka_pizza_tracker_topic, dumps(data, default=str).encode('utf-8'))
+        self._producer.flush()
 
     def job_created(self, job_id: str, filename: str, handler: str, uploader: str) -> None:
-        self._producer.send(settings.kafka_pizza_tracker_topic, {
+        self._publish({
             'type': 'job_created',
             'job_id': job_id,
             'filename': filename,
@@ -24,28 +28,29 @@ class KafkaMessageProducer(MessageProducer):
         })
 
     def job_evt_task(self, job_id: str, task: str) -> None:
-        self._producer.send(settings.kafka_pizza_tracker_topic, {
+        self._publish({
             'type': 'job_update',
             'job_id': job_id,
             'task': task
         })
 
     def job_evt_status(self, job_id: str, status: str) -> None:
-        self._producer.send(settings.kafka_pizza_tracker_topic, {
+        self._publish({
             'type': 'job_update',
             'job_id': job_id,
             'status': status
         })
 
     def job_evt_progress(self, job_id: str, progress: float) -> None:
-        self._producer.send(settings.kafka_pizza_tracker_topic, {
+        print(f'logging job_evt_progress from kafka producer. job_id: {job_id}, progress: {progress}')
+        self._publish({
             'type': 'job_update',
             'job_id': job_id,
             'progress': progress
         })
 
     def job_evt_committed(self, job_id: str, committed: int) -> None:
-        self._producer.send(settings.kafka_pizza_tracker_topic, {
+        self._publish({
             'type': 'job_update',
             'job_id': job_id,
             'committed': committed

--- a/etl/util.py
+++ b/etl/util.py
@@ -1,6 +1,9 @@
 """Miscellaneous utility functions"""
 import base64
+import logging
 import uuid
+
+from etl.config import settings
 
 
 def short_uuid() -> str:
@@ -11,3 +14,13 @@ def short_uuid() -> str:
 def process_file_stub(data: str, **kwargs):
     """A do-nothing-method to use as an example for the Python process config"""
     print(f'Received the data file {data} and the named arguments {kwargs}. Doing nothing.')
+
+
+def get_logger(name: str) -> logging.Logger:
+    log_level = settings.log_level
+    numeric_level = getattr(logging, log_level.upper(), None)
+    if not isinstance(numeric_level, int):
+        raise ValueError(f'Invalid log level: {log_level}')
+    logger = logging.getLogger(name)
+    logger.setLevel(numeric_level)
+    return logger


### PR DESCRIPTION
- Postgres was unused and so is being removed
- Pizza Tracker for processors was not fully implemented; with this update python processors that support Pizza Tracker will start a subprocess that runs the tracker, and the tracker has been updated to handle buffering commands from the named pipe and continuing to read until `END` is read.