### PR TITLE
fix issue with python processor with tracking turned on not able to terminate upon error condition

### DIFF
--- a/etl/object_store/interfaces.py
+++ b/etl/object_store/interfaces.py
@@ -12,11 +12,13 @@ class EventType(Enum):
     Put = 1
     Delete = 2
 
+
 @dataclass
 class ObjectEvent:
     """Represents an implementation-neutral file event"""
     object_id: ObjectId
     event_type: EventType
+
 
 class ObjectStore(abc.ABC):
     """Interface for object store service backend"""
@@ -30,7 +32,7 @@ class ObjectStore(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def upload_object(self, dest: ObjectId, src_file: str) -> None:
+    def upload_object(self, dest: ObjectId, src_file: str, metadata: Optional[Dict]) -> None:
         """Uploads a file to the object store
         :param dest: destination object
         :param src_file: local path to upload

--- a/etl/object_store/minio.py
+++ b/etl/object_store/minio.py
@@ -1,7 +1,7 @@
 """Contains the Minio implementation of the object store backend interface"""
 from io import BytesIO
 from pathlib import PurePosixPath
-from typing import Any, Iterable, Optional, Protocol
+from typing import Any, Iterable, Optional, Protocol, Dict
 
 from minio import Minio
 
@@ -67,8 +67,11 @@ class MinioObjectStore(ObjectStore):
     def download_object(self, src: ObjectId, dest_file: str) -> None:
         self._minio_client.fget_object(src.namespace, src.path, dest_file)
 
-    def upload_object(self, dest: ObjectId, src_file: str) -> None:
-        self._minio_client.fput_object(dest.namespace, dest.path, src_file)
+    def upload_object(self, dest: ObjectId, src_file: str, metadata: Optional[Dict]) -> None:
+        self._minio_client.fput_object(bucket_name=dest.namespace,
+                                       object_name=dest.path,
+                                       file_path=src_file,
+                                       metadata=metadata)
 
     def read_object(self, obj: ObjectId) -> bytes:
         response: Optional[MinioObjectResponse] = None


### PR DESCRIPTION
an issue was found whereby the python based processor with Pizza Tracker feature turned on do not terminate when the processing code throws an exception

this fix detects whether the Python subprocess in which the processor code is running encountered an error condition, if so it will break out of the loop and not invoke pizza_tracker 