### PR TITLE
Feature/log config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-
 # Copy using poetry.lock* in case it doesn't exist yet
 COPY ./pyproject.toml ./poetry.lock* /app/
 
+# Copy logging configuration and create logs dir
+COPY logging.conf /app/
+RUN mkdir -p /app/logs
+
 # Install dependencies
 RUN poetry install --no-root --no-dev
 

--- a/etl/__main__.py
+++ b/etl/__main__.py
@@ -1,11 +1,14 @@
 """Entry point for ETL worker"""
 from typing import AsyncIterable, Dict, List
+import logging.config
 
 from etl.config import settings
 from etl.event_processor import GeneralEventProcessor, EtlConfigEventProcessor
 from etl.messaging.kafka_producer import KafkaMessageProducer
 from etl.object_store.minio import MinioObjectStore
 from etl.tasking.faust import FaustTaskSink, FaustAppConfig
+
+logging.config.fileConfig(settings.logging_conf_file)
 
 faust_app_configs: List[FaustAppConfig] = []
 

--- a/etl/config.py
+++ b/etl/config.py
@@ -34,6 +34,7 @@ class Settings(BaseSettings):
     minio_notification_arn_etl_config: str = 'arn:minio:sqs::config:kafka'
     minio_notification_arn_etl_source_file: str = 'arn:minio:sqs::source:kafka'
 
+    logging_conf_file: str = 'logging.conf'
     log_level: str = 'debug'
 
 

--- a/logging.conf
+++ b/logging.conf
@@ -1,5 +1,5 @@
 [loggers]
-keys=root,modules
+keys=root,etl
 
 [handlers]
 keys=consoleHandler,fileHandler
@@ -20,16 +20,14 @@ args=(sys.stdout,)
 class=handlers.RotatingFileHandler
 level=INFO
 formatter=simpleFormatter
-args=('logs/modules.log', 'a', 10_000_000, 14) # rotate every 10MB, and keep 14 days of history
+args=('logs/cast_iron_worker.log', 'a', 10_000_000, 14) # rotate every 10MB, and keep 14 days of history
 
-# Modules Logger
-[logger_modules]
+[logger_etl]
 level=INFO
 handlers=consoleHandler,fileHandler
-qualname=padsi
+qualname=etl
 propagate=0
 
-# root logger
 [logger_root]
 level=INFO
 handlers=consoleHandler,fileHandler

--- a/logging.conf
+++ b/logging.conf
@@ -1,0 +1,35 @@
+[loggers]
+keys=root,modules
+
+[handlers]
+keys=consoleHandler,fileHandler
+
+[formatters]
+keys=simpleFormatter
+
+[formatter_simpleFormatter]
+format=[%(asctime)s] [%(levelname)-8s] [%(name)-12s] %(message)s
+
+[handler_consoleHandler]
+class=StreamHandler
+level=INFO
+formatter=simpleFormatter
+args=(sys.stdout,)
+
+[handler_fileHandler]
+class=handlers.RotatingFileHandler
+level=INFO
+formatter=simpleFormatter
+args=('logs/modules.log', 'a', 10_000_000, 14) # rotate every 10MB, and keep 14 days of history
+
+# Modules Logger
+[logger_modules]
+level=INFO
+handlers=consoleHandler,fileHandler
+qualname=padsi
+propagate=0
+
+# root logger
+[logger_root]
+level=INFO
+handlers=consoleHandler,fileHandler


### PR DESCRIPTION
## Description
Adds support for logging configuration for cast iron worker. The current configuration added adds logging to file and file rotation. 

## Testing
1. Run `make build` within the cast-iron-worker directory to build the cast iron worker image
2. Start a container based on this image. You should see a logging.conf within the `/app` directory. There should also be a `/app/logs` directory
3. Logs will be written to `/logs/cast_iron_worker.log` as the worker runs